### PR TITLE
Update to include the dark-side style module

### DIFF
--- a/streamfun-page/streamfun-page-buttons.html
+++ b/streamfun-page/streamfun-page-buttons.html
@@ -6,7 +6,7 @@ This code may only be used under the BSD style license found at https://streamfu
 <link rel="import" href="//pcpolymer.firebaseapp.com/bower_components/polymer/polymer.html">
 <link rel="import" href="//powco.firebaseapp.com/powco-data/powco-data.html">
 <link rel="import" href="//pcpolymer.firebaseapp.com/bower_components/paper-button/paper-button.html">
-
+<link rel="import" href="dark-side/dark-side.html">
 <!--
 `<streamfun-page-buttons>` is an app page that has a bunch of buttons each of which trigger an
 action on the streamfun action app.
@@ -15,6 +15,7 @@ action on the streamfun action app.
 -->
 <dom-module id="streamfun-page-buttons">
   <template>
+    <style include="dark-side"></style>
     <powco-data id="trigger" key="streamfun~triggers"></powco-data>
     <template is="dom-repeat" items="[[alerts]]">
       <paper-button raised on-tap="_updateTrigger">[[item.label]]</paper-button>


### PR DESCRIPTION
*/ from polymer style docs @https://www.polymer-project.org/1.0/docs/devguide/styling.html#style-modules//
Using the shared styles is a two-step process: you need to use a <link> tag to import the module, and a <style> tag to include the styles in the correct place.

To use a style module in an element:

<!-- import the module  -->
<link rel="import" href="../shared-styles/shared-styles.html">
<dom-module id="x-foo">
  <template>
    <!-- include the style module by name -->
    <style include="shared-styles"></style>
    <style>:host { display: block; }</style>
    Hi
  </template>
  <script>Polymer({is: 'x-foo'});</script>
</dom-module>